### PR TITLE
Fix: Deuce indicator spans entire screen in landscape mode

### DIFF
--- a/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/ScoreScreen.kt
+++ b/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/ScoreScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
@@ -175,7 +176,7 @@ fun ScoreScreenPortrait(
             )
 
             if (gameSettings.markDeuce && gameState.isDeuce) {
-                DeuceIndicator()
+                DeuceIndicator(modifier = Modifier.fillMaxWidth())
             }
 
             PlayerScoreCard(

--- a/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/components/CentralControls.kt
+++ b/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/components/CentralControls.kt
@@ -2,10 +2,12 @@ package com.soyvictorherrera.scorecount.ui.scorescreen.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
@@ -37,7 +39,11 @@ fun CentralControls(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.fillMaxHeight(),
+        modifier =
+            modifier
+                .fillMaxHeight()
+                .width(IntrinsicSize.Max),
+        // This forces the column to be as wide as its widest child (the buttons)
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -53,6 +59,7 @@ fun CentralControls(
         }
 
         Column(
+            modifier = Modifier.fillMaxWidth(), // This column will now respect the parent's constrained width
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
@@ -65,7 +72,8 @@ fun CentralControls(
                 )
             }
             if (gameSettings.markDeuce && gameState.isDeuce) {
-                DeuceIndicator()
+                // This will fill the width defined by the parent, which is the same as the buttons'
+                DeuceIndicator(modifier = Modifier.fillMaxWidth())
             }
         }
 

--- a/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/components/DeuceIndicator.kt
+++ b/app/src/main/java/com/soyvictorherrera/scorecount/ui/scorescreen/components/DeuceIndicator.kt
@@ -2,7 +2,6 @@ package com.soyvictorherrera.scorecount.ui.scorescreen.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -17,13 +16,12 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun DeuceIndicator(modifier: Modifier = Modifier) {
     Surface(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
         border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
             Text(


### PR DESCRIPTION
## Fix: Deuce indicator spans entire screen in landscape mode

**Related Issue:** Closes #38

### Summary
- Problem: In landscape mode during deuce state, the deuce indicator expanded to cover the entire screen width, completely obscuring player score cards and making the app unusable
- Solution: Removed hardcoded `fillMaxWidth()` from DeuceIndicator component and used `IntrinsicSize.Max` pattern to constrain width to match control buttons in landscape mode
- Impact: App is now fully functional during deuce in all orientations, score cards remain visible and interactive

### Key Changes
- `ui/scorescreen/components/DeuceIndicator.kt:19` - Removed hardcoded `fillMaxWidth()`, accept width via modifier parameter
- `ui/scorescreen/components/CentralControls.kt:43` - Added `.width(IntrinsicSize.Max)` to constrain column width to buttons
- `ui/scorescreen/components/CentralControls.kt:74` - Pass `Modifier.fillMaxWidth()` respecting parent constraint
- `ui/scorescreen/ScoreScreen.kt:178` - Explicitly pass `Modifier.fillMaxWidth()` for portrait full-width behavior

### Testing
Steps to verify:
1. Launch app and rotate to landscape mode
2. Play until deuce state (both players 10+ with equal scores)
3. Verify deuce indicator matches button width in central controls
4. Verify both score cards are fully visible and interactive
5. Rotate to portrait mode and verify indicator spans full content width
6. Test in both light and dark themes

**Result:** ✅ Deuce indicator displays correctly in both orientations without covering score cards

### Notes
Used Compose's `IntrinsicSize.Max` to derive the indicator width from existing UI elements (buttons) rather than hardcoding dimensions. This maintains visual consistency and makes the component reusable across different layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)