### PR TITLE
fix: Reset game now always sets serve indicator to Player 1

### DIFF
--- a/app/src/main/java/com/soyvictorherrera/scorecount/domain/calculator/ScoreCalculator.kt
+++ b/app/src/main/java/com/soyvictorherrera/scorecount/domain/calculator/ScoreCalculator.kt
@@ -159,7 +159,8 @@ object ScoreCalculator {
      * @param player1Name The name of player 1
      * @param player2Name The name of player 2
      * @param settings The game settings
-     * @param lastGameWinnerId Optional: ID of the last game winner (determines first server)
+     * @param lastGameWinnerId Optional: ID of the last game winner
+     *   (determines first server when winnerServesNextGame is true)
      * @return A new game state in initial configuration
      */
     fun resetGame(
@@ -168,18 +169,14 @@ object ScoreCalculator {
         player1Name: String,
         player2Name: String,
         settings: GameSettings,
-        lastGameWinnerId: Int? = null,
-        currentServerId: Int? = null
+        lastGameWinnerId: Int? = null
     ): GameState {
         val firstServer =
             if (settings.winnerServesNextGame && lastGameWinnerId != null) {
                 // Winner serves next game
                 lastGameWinnerId
-            } else if (!settings.winnerServesNextGame && currentServerId != null) {
-                // Alternate server from current server
-                if (currentServerId == player1Id) player2Id else player1Id
             } else {
-                // Default to player 1
+                // Always reset to player 1 (initial state)
                 player1Id
             }
 

--- a/app/src/main/java/com/soyvictorherrera/scorecount/domain/usecase/ResetGameUseCase.kt
+++ b/app/src/main/java/com/soyvictorherrera/scorecount/domain/usecase/ResetGameUseCase.kt
@@ -31,8 +31,7 @@ class ResetGameUseCase
                     player1Name = currentState.player1.name,
                     player2Name = currentState.player2.name,
                     settings = settings,
-                    lastGameWinnerId = winnerId,
-                    currentServerId = currentState.servingPlayerId
+                    lastGameWinnerId = winnerId
                 )
 
             scoreRepository.updateGameState(newState)

--- a/app/src/test/java/com/soyvictorherrera/scorecount/domain/usecase/ScoreUseCasesTest.kt
+++ b/app/src/test/java/com/soyvictorherrera/scorecount/domain/usecase/ScoreUseCasesTest.kt
@@ -281,10 +281,9 @@ class ScoreUseCasesTest {
             // When - Player 2 won last game
             useCase(lastGameWinnerId = 2)
 
-            // Then - Server alternates, not based on winner
+            // Then - Always resets to Player 1 (initial state), not based on winner
             val newState = fakeScoreRepository.getGameState().value
-            // Server should be player 2 (alternates from player 1)
-            assertEquals(2, newState.servingPlayerId)
+            assertEquals(1, newState.servingPlayerId)
         }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes bug where consecutive resets would toggle the serve indicator between players instead of consistently resetting to Player 1.

## Problem
When `winnerServesNextGame` setting was `false`, the `resetGame()` logic would alternate the server from the current state on each reset:
- Reset 1: P2 → P1 ✓
- Reset 2: P1 → P2 ✗ (wrong!)
- Reset 3: P2 → P1 ✓  
- Reset 4: P1 → P2 ✗ (wrong!)

This violated the principle of least surprise - users expect "reset" to return to initial state every time.

## Root Cause
The `currentServerId` parameter was intended for **set transitions** during gameplay (when a set ends and a new one begins), but was being misused for **manual resets**. Manual reset should return to initial state (Player 1 serving), not alternate from the current state.

## Solution
- Removed the alternation logic branch that toggled servers
- Removed the unused `currentServerId` parameter from `resetGame()` signature
- Simplified logic to: winner serves (if `winnerServesNextGame` enabled) OR always Player 1

**Before:**
```kotlin
if (!settings.winnerServesNextGame && currentServerId != null) {
    // Alternate server from current server
    if (currentServerId == player1Id) player2Id else player1Id
}
```

**After:**
```kotlin
val firstServer =
    if (settings.winnerServesNextGame && lastGameWinnerId != null) {
        lastGameWinnerId  // Winner serves
    } else {
        player1Id  // Always reset to Player 1 (initial state)
    }
```

## Changes
- **ScoreCalculator.kt:165-181** - Simplified resetGame(), removed unused parameter
- **ResetGameUseCase.kt:27-35** - Updated to match new signature  
- **ScoreCalculatorTest.kt:598-701** - Added 4 new unit tests for consecutive resets
- **ScoreUseCasesTest.kt:265-287** - Fixed 1 existing test that expected buggy behavior
- **MEMORY.md** - Documented the fix with full analysis

## Testing
- ✅ All 120 unit tests pass (4 new tests added)
- ✅ Build successful
- ✅ Lint checks pass
- ✅ detekt checks pass
- ✅ Pre-commit hooks pass

## Test Plan
1. Open the app
2. Play until Player 2 is serving (after ~2 points with default settings)
3. Tap "Reset Game"
4. **Expected:** Serve indicator shows Player 1
5. Tap "Reset Game" again (without scoring)
6. **Expected:** Serve indicator STILL shows Player 1 (not toggling to Player 2)
7. Repeat step 6 several times
8. **Expected:** Serve indicator always stays on Player 1

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)