### PR TITLE
docs: add writing-prose-like-a-human skill and disable Jetifier

### DIFF
--- a/.agents/skills/writing-prose-like-a-human/ATTRIBUTION.md
+++ b/.agents/skills/writing-prose-like-a-human/ATTRIBUTION.md
@@ -1,0 +1,12 @@
+## Attribution
+
+This work is derived from [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) by Wikipedia contributors, licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Changes were made. The original material was restructured into an agent skill format with YAML frontmatter, reorganized into rule-based sections, and rewritten with additional examples and guidance for use as LLM instructions.
+
+This derivative work is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Metadata
+
+- **Author**: Kyle Hughes
+- **Date**: 2026-02-19

--- a/.agents/skills/writing-prose-like-a-human/REFERENCE.md
+++ b/.agents/skills/writing-prose-like-a-human/REFERENCE.md
@@ -1,0 +1,394 @@
+# Writing Prose Like a Human — Reference
+
+## 1. Content: Substance Over Significance
+
+### The significance trap
+
+AI inflates everything. A local park becomes "a vital green space that plays a significant role in the community's well-being." A company's founding becomes "a watershed moment that would shape the industry's evolving landscape." A person's career becomes "a testament to their steadfast dedication."
+
+Human writers let facts speak. The park is 12 acres and has a playground. The company was founded in 2003. The person worked there for 20 years.
+
+**Before:**
+> The 2015 merger represented a pivotal turning point for the company, solidifying its position as a key player in the evolving landscape of renewable energy and leaving an indelible mark on the broader movement toward sustainability.
+
+**After:**
+> The company merged with SolarCo in 2015, doubling its manufacturing capacity to 400 MW per year.
+
+The first sentence uses 40 words to say something was important. The second uses 16 words to say what actually happened.
+
+### The attribution trap
+
+AI lists sources to prove notability rather than reporting what sources say. "Featured in The New York Times, CNN, and Forbes" is AI padding. A human writer would say what those sources reported, or wouldn't mention them at all.
+
+**Before:**
+> The restaurant has garnered widespread acclaim, having been featured in The New York Times, profiled by Bon Appetit, and recognized by the James Beard Foundation, underscoring its significance in the culinary landscape.
+
+**After:**
+> The New York Times called it "the best new Thai restaurant outside Bangkok" in a 2022 review. It won a James Beard Award in 2023.
+
+### The analysis trap
+
+AI appends participial phrases ("-ing" clauses) that editorialize after stating a fact. These phrases add opinion disguised as analysis and almost never carry information.
+
+Common offenders:
+- "highlighting its importance"
+- "reflecting broader trends"
+- "underscoring the significance"
+- "ensuring continued relevance"
+- "showcasing the region's diversity"
+- "emphasizing the need for continued investment"
+- "solidifying its reputation as"
+- "captivating audiences worldwide"
+
+**Before:**
+> The university enrolled 5,000 new students in 2024, reflecting broader trends in higher education and highlighting the institution's enduring commitment to academic excellence.
+
+**After:**
+> The university enrolled 5,000 new students in 2024, up from 3,200 the year before.
+
+The fix is almost always the same: cut everything after the fact. If the analysis matters, make it its own sentence with its own evidence.
+
+### The challenges formula
+
+AI writes about difficulties using a predictable three-act structure: acknowledge the positive, introduce challenges with "Despite", then resolve with optimism about the future. This "Despite X, faces challenges Y, but future Z" formula is one of the most recognizable AI paragraph patterns.
+
+**Before:**
+> Despite its rich cultural heritage and vibrant community, the neighborhood faces significant challenges including rising housing costs and aging infrastructure. However, community leaders remain committed to addressing these issues, setting the stage for a more equitable and sustainable future.
+
+**After:**
+> Rents in the neighborhood have increased 40% since 2019. Several buildings on Oak Street need foundation repairs. The city council rejected a bond measure to fund the work in November.
+
+Human writers discuss problems without the redemptive arc. Sometimes things are just bad.
+
+## 2. Vocabulary: The Complete Blacklist
+
+### Significance and importance
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| pivotal | Inflated importance | important, or cut |
+| crucial | Inflated importance | important, necessary, or cut |
+| vital | Inflated importance | important, necessary, or cut |
+| key (adjective) | Inflated importance | main, central, or rephrase |
+| paramount | Inflated importance | most important, or cut |
+| testament (to) | Unearned gravitas | evidence, sign, or cut |
+| watershed moment | Inflated importance | state what changed |
+| indelible mark | Inflated permanence | state the lasting effect |
+| lasting/enduring legacy | Inflated permanence | state what persists |
+| deeply rooted | Vague history | long-standing, old, or cut |
+| groundbreaking (figurative) | Inflated novelty | new, first, original |
+| leaves a lasting impact | Inflated permanence | state the effect |
+| plays a significant role | Vague importance | affects, matters |
+| focal point | Inflated centrality | center, focus, main concern |
+| cornerstone | Inflated centrality | basis, foundation |
+| broader movement | Vague contextualization | name the movement |
+| evolving landscape | Vague change | state what changed |
+| in the annals of | Pompous historicizing | in the history of, or cut |
+| instrumental | Inflated importance | important, useful, helpful |
+| reminder (as in "is a reminder") | Unearned gravitas | evidence, sign, or cut |
+| key turning point | Inflated importance | state what changed |
+| marks/represents a shift | Inflated importance | state what changed |
+| contributing to the | Vague causation | state the contribution, or cut |
+
+### Sophistication and elegance
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| delve (into) | False depth | look at, examine, discuss |
+| intricate | False complexity | detailed, complex, or describe it |
+| interplay | False sophistication | relationship, interaction, connection |
+| garner | Stiff formality | get, receive, earn, win |
+| underscore (verb) | False emphasis | stress, show, reveal |
+| showcase (verb) | Promotional tone | show, display, present, has |
+| foster | Bureaucratic tone | encourage, support, build |
+| encompass | False breadth | include, cover, contain |
+| resonate (with) | Vague emotional claim | appeal to, affect, move |
+| align (with) | Corporate jargon | match, agree with, fit, support |
+| navigate | Inflated difficulty | handle, manage, deal with |
+| leverage | Corporate jargon | use |
+| elevate | Inflated improvement | raise, improve, promote |
+| reimagine | Inflated creativity | redesign, rethink, redo |
+| orchestrate | Inflated coordination | organize, arrange, plan |
+| paradigm | Academic pretension | model, approach, framework |
+| ethos | Academic pretension | values, principles, character |
+| nuance/nuanced | False sophistication | detail, subtlety, or be specific |
+| multifaceted | False complexity | complex, varied, many-sided |
+| bespoke | Unnecessary formality | custom, custom-made |
+| curate/curated | Inflated intentionality | choose, select, collect |
+| embark (on) | Inflated journey metaphor | start, begin |
+| facilitate | Bureaucratic tone | help, enable, allow |
+| instrumental | Inflated importance | important, useful, helpful |
+| highlight (verb) | False emphasis | show, point out, reveal |
+| exemplify | Promotional puffery | show, illustrate |
+| cultivate (figurative) | Bureaucratic tone | build, encourage, grow |
+| intricacies | False complexity | details, complexities |
+| valuable | Inflated worth | useful, helpful, or cut |
+| renowned | Inflated status | well-known, respected |
+| featuring | Copula avoidance | with, including, has |
+
+### Decorative adjectives
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| vibrant | Empty decoration | cut, or describe what makes it lively |
+| rich (cultural/history) | Empty decoration | cut, or describe specifically |
+| profound | Inflated depth | deep, significant, or cut |
+| enduring | Inflated permanence | long-lasting, persistent, or cut |
+| bustling | Empty decoration | busy, crowded, or state the numbers |
+| stunning | Promotional tone | cut, or describe specifically |
+| breathtaking | Promotional tone | cut, or describe specifically |
+| dynamic | Empty decoration | cut, or describe the change |
+| meticulous | Inflated precision | careful, thorough, detailed |
+| robust | Engineering jargon as decoration | strong, reliable, solid |
+| seamless | Inflated smoothness | smooth, easy, simple |
+| comprehensive | Inflated completeness | complete, thorough, full |
+| esteemed | Inflated status | respected, well-known |
+| commendable | Unearned praise | cut |
+| whimsical | Decorative filler | cut, or describe what makes it playful |
+
+### Filler phrases and hedges
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| nestled (in) | False coziness | located in, in, situated in |
+| in the heart of | Inflated centrality | in, in central, in downtown |
+| boasts | Promotional tone | has |
+| offers a glimpse into | Vague teaser | shows |
+| tapestry (abstract) | False richness | cut — describe the actual thing |
+| in today's fast-paced world | Empty framing | cut entirely |
+| it is worth noting | Throat-clearing | just state the thing |
+| it's important to remember | Throat-clearing | just state the thing |
+| no discussion would be complete without | Throat-clearing | just state the thing |
+| at the end of the day | Empty idiom | cut |
+| in the realm/world of | Inflated domain framing | in |
+| at its core | Throat-clearing | cut, or just state the thing |
+| a delicate balance | False nuance | describe the actual trade-off |
+| a double-edged sword | Cliche analysis | state both effects plainly |
+| While specific details are limited/scarce | Knowledge-gap speculation | state what is known, or say "unknown" |
+| not widely available/documented/disclosed | Knowledge-gap speculation | "unknown" or "not documented" |
+| based on available information | Knowledge-gap hedge | cut — just state the information |
+| keeps personal details private | Speculative excuse for gaps | "details are not public" or cut |
+| maintains a low profile | Speculative excuse for gaps | cut |
+
+### Chatbot leakage
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| Certainly! | Sycophantic opener | cut |
+| I hope this helps | Chatbot valediction | cut |
+| let me know if... | Chatbot valediction | cut |
+| as of my last training | Training data disclaimer | cut or state the actual date |
+| as an AI language model | Identity disclaimer | cut |
+| Would you like me to... | Prompt for continuation | cut |
+| Of course! | Sycophantic opener | cut |
+| Great question! | Sycophantic opener | cut |
+| You're absolutely right! | Sycophantic validation | cut |
+| is there anything else | Chatbot valediction | cut |
+| more detailed breakdown | Chatbot offer to elaborate | cut |
+| here is a | Chatbot preamble | cut |
+
+### Vague attribution
+
+| Word/phrase | What it signals | Write instead |
+|-------------|----------------|---------------|
+| Industry reports suggest | Weasel wording | name the report |
+| Experts/observers/critics argue | Weasel wording | name the person |
+| Some critics argue | Weasel wording | name the critic, or cut |
+| several sources/publications | Overgeneralization | name them, or state the count |
+| such as (before exhaustive lists) | False non-exhaustiveness | list the items without "such as" |
+| profiled in | Notability inflation | say what the profile said, or cut |
+| active social media presence | Notability inflation | state follower count or cut |
+| independent coverage | Notability inflation | name the outlet and what it said |
+
+## 3. Grammar: How Sentences Should Work
+
+### Copulas are fine
+
+"Is" and "are" are the backbone of clear prose. Don't replace every "is" with "serves as", "stands as", "represents", "constitutes", "marks", "offers", or "features." Those replacements add syllables without adding meaning.
+
+Better yet, find the active verb hiding inside the noun phrase. Three levels:
+- Bad: "The tool serves as a validation mechanism for user inputs."
+- Better: "The tool is a validation mechanism."
+- Best: "The tool validates inputs."
+
+**Before:**
+> The library serves as a cornerstone of the community, standing as a testament to the city's enduring commitment to education.
+
+**After:**
+> The library is the largest public building in the city. It has been open since 1952.
+
+### Parallelism with restraint
+
+"Not only... but also..." is a valid English construction. Using it in every other paragraph is an AI tell. The structure creates false drama — it implies that the second element is surprising or additionally noteworthy, which it usually isn't.
+
+The same applies to the negation variant: "It is not just about X, it's Y" and "not X, it's Y" / "no X, no Y, just Z." These parallel constructions serve the same false-drama purpose — framing ordinary statements as revelations.
+
+**Before:**
+> Not only does the program provide job training, but it also fosters community engagement and promotes social cohesion, underscoring the organization's commitment to holistic development.
+
+**After:**
+> The program provides job training and runs community events on weekends.
+
+### The rule of three
+
+AI defaults to lists of three: three adjectives, three examples, three bullet points. Real writing doesn't follow this pattern reliably. Sometimes two examples are enough. Sometimes you need five. Sometimes one is the right number.
+
+**Before:**
+> The city is known for its vibrant arts scene, rich culinary traditions, and stunning natural beauty.
+
+**After:**
+> The city has a symphony orchestra and about 40 restaurants.
+
+### Elegant variation is a trap
+
+When you need to refer to the same thing twice, repeat the word. Don't rotate through synonyms to avoid repetition.
+
+**Before:**
+> The bridge was completed in 1910. The structure connects the north and south banks. The span carries approximately 20,000 vehicles per day. The crossing was designated a historic landmark in 1985.
+
+**After:**
+> The bridge was completed in 1910. It connects the north and south banks and carries about 20,000 vehicles per day. The bridge was designated a historic landmark in 1985.
+
+"The structure... the span... the crossing..." is a tell because it prioritizes surface-level variety over clarity. Use "it" or repeat the noun.
+
+### False ranges
+
+"From X to Y" requires X and Y to be endpoints of a measurable scale. "From classical to contemporary" works. "From biology to politics" does not — those aren't endpoints of anything. AI uses this construction to gesture at breadth without being specific.
+
+**Before:**
+> The curriculum covers everything from biology to the arts, providing students with a comprehensive educational experience.
+
+**After:**
+> The curriculum includes biology, chemistry, English, and art history.
+
+## 4. Structure: How Documents Should Be Organized
+
+### No conclusion sections
+
+Don't end articles, sections, or documents with "In summary", "In conclusion", or "Overall." If the preceding text made its point, the reader doesn't need a recap. A section that ends with its last substantive fact is stronger than one that ends with a restatement.
+
+### No "challenges and future prospects" formula
+
+This is the single most recognizable AI document structure: a "Challenges" or "Challenges and Future Prospects" section near the end that acknowledges difficulties and then resolves them with optimism. Real writing either discusses challenges in context (where they arise) or states them without promising resolution.
+
+### Headings in sentence case
+
+Title Case Headings Are A Tell Because Wikipedia And Most Style Guides Use Sentence Case. Unless the style guide specifically requires title case, use sentence case: capitalize the first word and proper nouns only.
+
+### Bold for emphasis, not for inventory
+
+AI bolds every key term on first mention, creating a visual pattern that reads like a glossary. Use bold sparingly — for genuine emphasis, not for marking terms.
+
+### Prose over bullet lists
+
+Bullet lists are for genuinely list-shaped data: steps in a process, items in an inventory, options to choose between. If the content has logical flow and connections between ideas, prose is clearer. The AI pattern is to break flowing content into bullets with bold headers:
+
+**AI pattern:**
+> - **Scalability:** The system is designed to scale across different use cases.
+> - **Reliability:** It provides consistent performance under varying conditions.
+> - **Security:** Multiple layers of protection ensure data safety.
+
+**Human pattern:**
+> The system scales to about 10,000 concurrent users. It has had 99.97% uptime since launch. Authentication uses OAuth 2.0 with rate limiting.
+
+### Tables only for actual data
+
+Tables work when data has two or more independent dimensions (rows and columns that each mean something). A table with one column of labels and one column of values is usually just a list pretending to be a table. Two or three items never need a table.
+
+### Em dashes: sparingly
+
+Em dashes are a legitimate punctuation mark. AI overuses them — often in places where a comma, colon, or parenthetical would work better — creating a breathless, magazine-feature rhythm. One or two per page is fine. More is a pattern.
+
+### Straight quotation marks
+
+Some AI models (notably ChatGPT and DeepSeek) default to curly quotes ("\u2026") and curly apostrophes (\u2019). Use straight quotes ("...") and straight apostrophes (') for consistency, unless the style guide specifies otherwise. Curly quotes in plain-text contexts (code, Markdown, commit messages) are a tell.
+
+### No moralizing or safety padding
+
+AI wraps factual content in moral commentary that the reader didn't ask for. "It is crucial to approach this topic with sensitivity" before a historical account, or "We must remember the human cost" after a list of casualties, are AI tells. The facts are serious on their own. Telling the reader how to feel about them is condescending.
+
+**Before:**
+> It is important to approach the history of this conflict with sensitivity and nuance. The battle resulted in approximately 3,000 casualties. We must remember that behind these numbers were real people with families and dreams.
+
+**After:**
+> The battle killed about 3,000 soldiers over two days.
+
+## 5. Tone: Neutral Without Being Sterile
+
+### Cut promotional language
+
+"Vibrant", "renowned", "groundbreaking", "stunning", "breathtaking", "must-visit", "world-class" — these are travel brochure words. They claim quality without evidence. Replace them with specific facts that let the reader judge quality.
+
+**Before:**
+> The museum is a world-class institution renowned for its stunning collection of breathtaking masterworks.
+
+**After:**
+> The museum has 30,000 works. Its Vermeer collection (four paintings) is the largest outside the Netherlands.
+
+### Cut hedging language
+
+"It's important to note", "it is worth remembering", "one cannot overstate" — these phrases prepare the reader for information without delivering it. Just deliver the information.
+
+**Before:**
+> It is worth noting that the building's architectural significance cannot be overstated, as it represents a pivotal example of the Art Deco movement.
+
+**After:**
+> The building is one of three Art Deco theaters still operating in the state.
+
+### Cut chatbot language
+
+"Certainly!", "I hope this helps", "Would you like me to elaborate?", "Great question!" — these are conversational tics from a chatbot interface. They have no place in written prose.
+
+### State facts, opinions, and unknowns plainly
+
+Facts: "The bridge is 200 meters long."
+Opinions: "This approach is simpler." (Not: "This approach arguably represents a more streamlined methodology.")
+Unknowns: "The date is unknown." (Not: "While specific details regarding the precise date remain limited in currently available sources, it is believed that...")
+
+Specificity is the best form of credibility. A concrete fact does more for your authority than any claim of significance.
+
+## 6. Signs of Authentic Human Writing
+
+These positive patterns signal human authorship. They're worth cultivating:
+
+- **Comfortable with "is/are/has."** Human writers don't avoid plain copulas. "The building is on Main Street" is fine. It doesn't need to "stand at the intersection of Main Street and urban possibility."
+
+- **Inconsistent but not sloppy.** Some paragraphs are long, some are short. Some sentences are fragments. The variation tracks the shape of the ideas, not a template.
+
+- **Willingness to leave things unsaid.** Not every paragraph needs a concluding sentence. Not every section needs a transition. Not every topic needs a "broader significance" gloss.
+
+- **Specific facts over general significance claims.** "$2.4 million budget" beats "substantial investment." "Founded in 1973" beats "a long-standing institution." "12 employees" beats "a dedicated team."
+
+- **Direct acknowledgment of gaps.** "The architect is unknown" is better than "While the identity of the architect has not been definitively established in available historical records, the building's design reflects influences consistent with the prevailing architectural trends of the era."
+
+- **Natural repetition over synonym rotation.** Using the same word twice is fine. Using four different synonyms for the same thing ("the building", "the structure", "the edifice", "the property") is a tell.
+
+- **Opinions without scaffolding.** "This is the better approach" beats "Not only is this approach more effective, but it also offers significant advantages in terms of maintainability and long-term sustainability."
+
+- **Dry specificity.** The most human-sounding writing is often just a list of facts with no commentary. Dates, numbers, names, places. No adjectives, no significance claims, no participial editorializing.
+
+## 7. Quick Self-Edit Checklist
+
+Run these checks on any prose before finalizing:
+
+- [ ] Search for "pivotal", "crucial", "testament", "vibrant", "tapestry" (abstract), "landscape" (abstract), "delve", "intricate", "underscore", "showcase", "foster", "garner", "leverage", "navigate", "robust", "seamless" — cut or replace each
+- [ ] Search for "-ing" phrases at end of sentences — cut any that editorialize rather than describe action
+- [ ] Search for "serves as", "stands as" — replace with "is"
+- [ ] Search for "boasts" — replace with "has"
+- [ ] Search for "Not only... but..." — keep max 1 per document
+- [ ] Search for "Additionally," / "Furthermore," / "Moreover," at sentence start — rephrase or cut
+- [ ] Search for "Despite... challenges..." — rewrite without the formula
+- [ ] Search for "In summary" / "In conclusion" / "Overall" at section ends — cut
+- [ ] Search for "nestled" / "in the heart of" — replace with plain location
+- [ ] Search for "rich cultural heritage" / "vibrant community" / "stunning" / "breathtaking" — cut or replace with specifics
+- [ ] Check that no section ends with a summary or significance sentence
+- [ ] Verify each adjective carries specific, non-decorative meaning
+- [ ] Check for elegant variation — are you rotating synonyms for the same thing?
+- [ ] Check for the rule of three — do all your lists happen to have three items?
+- [ ] Check em dash frequency — more than two per page is suspect
+- [ ] Search for "highlights", "exemplifies", "renowned", "valuable" — cut or replace
+- [ ] Search for "Experts argue" / "Industry reports" / "observers" — name the source or cut
+- [ ] Search for "While specific details" / "based on available information" — cut or state what's known
+- [ ] Search for curly quotes and apostrophes — replace with straight equivalents
+- [ ] Search for "It is not just about" / "not X, it's Y" — rephrase
+- [ ] Search for "marks [a]" / "represents [a]" / "offers [a]" / "features [a]" — replace with "is" or "has"

--- a/.agents/skills/writing-prose-like-a-human/SKILL.md
+++ b/.agents/skills/writing-prose-like-a-human/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: writing-prose-like-a-human
+description: Produces prose that reads as authentically human by avoiding statistical patterns common to LLM output. Use when writing or editing prose, documentation, READMEs, PR descriptions, or any text where the output must not read like AI-generated content.
+---
+
+# Writing Prose Like a Human
+
+## Core Principle
+
+AI writing has a statistical signature: regression to the mean. Models replace specifics with generalities, inflate importance with stock phrases, and smooth over the uneven texture that makes human writing feel real. The result reads like a press release about everything.
+
+Human writing is specific, uneven, and comfortable with imperfection. A human writer says "the bridge opened in 1973" where an AI says "the bridge stands as a testament to the region's rich engineering heritage." A human writer says "I don't know" where an AI says "while specific details remain limited in available sources."
+
+The antidote is concrete detail and restraint. Say what happened. Skip the commentary about why it matters. Trust the reader to draw their own conclusions.
+
+## The Five Rules
+
+### 1. Be specific, not significant
+
+State facts without editorializing their importance. Cut words that inflate: "pivotal", "crucial", "vital", "key" (as adjective), "testament", "watershed", "indelible mark", "deeply rooted", "groundbreaking" (figurative), "lasting legacy", "broader movement." Let facts carry their own weight.
+
+**Before:**
+> The 1987 renovation played a pivotal role in shaping the building's enduring legacy, serving as a testament to the community's deeply rooted commitment to architectural preservation.
+
+**After:**
+> The building was renovated in 1987. The city council funded the project after the roof collapsed during a storm.
+
+The second version is more informative. The first version says the renovation was important without saying why.
+
+### 2. Use plain verbs
+
+Write "is", "are", "has" instead of "serves as", "stands as", "represents." Write "shows" not "showcases", "stresses" not "underscores", "has" not "boasts" or "features." Plain copulas are the backbone of clear prose. Don't replace them with verbs that sound more impressive but mean the same thing.
+
+Better yet, find the active verb hiding inside the noun phrase. "The tool serves as a validation mechanism" becomes "The tool is a validation mechanism" (better), which becomes "The tool validates inputs" (best).
+
+**Before:**
+> The museum showcases an extensive collection that encompasses works from diverse artistic movements, offering visitors a glimpse into the region's vibrant cultural tapestry.
+
+**After:**
+> The museum has paintings from the 16th through 20th centuries, mostly Dutch and Flemish.
+
+### 3. End sentences at the fact
+
+Do not append participial commentary — those "-ing" phrases that editorialize after the main clause. "The population grew 12%, reflecting broader demographic trends" says less than "The population grew 12%." The participial phrase adds opinion disguised as analysis.
+
+Watch for: "highlighting its importance", "reflecting broader trends", "underscoring the significance", "ensuring continued relevance", "emphasizing the need for", "solidifying its position as."
+
+**Before:**
+> The company opened a second factory in 2019, highlighting its commitment to expanding operations and underscoring the region's growing economic significance.
+
+**After:**
+> The company opened a second factory in 2019.
+
+### 4. Vary your rhythm
+
+Mix sentence lengths. Some sentences should be short. Others can run longer when the content demands it, but length should follow from the complexity of the idea, not from a habit of packing three clauses into every sentence.
+
+Don't default to the rule of three. Two items or four items are fine. One is fine. Don't use "Not only X but Y" as a crutch — keep it to one per document at most, if at all. Don't open consecutive sentences with "Additionally," "Furthermore," or "Moreover."
+
+**Before:**
+> Not only does the festival celebrate local traditions, but it also fosters community engagement, promotes cultural awareness, and attracts visitors from across the region. Additionally, it serves as a platform for emerging artists. Furthermore, it contributes to the local economy.
+
+**After:**
+> The festival runs for three days each September. About 200 local vendors set up stalls. Attendance has been around 15,000 since 2018.
+
+### 5. Earn every adjective
+
+Cut "vibrant", "rich" (cultural), "profound", "intricate", "enduring", "bustling", "stunning", "breathtaking", "dynamic", "meticulous", "robust", "comprehensive", "seamless", "multifaceted" unless they carry specific, non-decorative meaning. If removing the adjective doesn't change the meaning, remove it.
+
+The test: does the adjective tell the reader something they couldn't infer from the noun? "A tall building" works because not all buildings are tall. "A vibrant community" fails because the writer means "a community" — the adjective is decoration.
+
+**Before:**
+> Nestled in the heart of the vibrant downtown district, the bustling market offers a rich tapestry of diverse culinary experiences.
+
+**After:**
+> The market is on 4th Street between Pine and Oak. It has about 30 food stalls.
+
+## Vocabulary Watchlist
+
+These words and phrases appear at statistically elevated rates in LLM output. Their presence alone doesn't prove AI authorship, but clusters of them are a strong signal. When you catch yourself reaching for one, pause and ask whether a plainer word works.
+
+### Significance inflation
+
+| Avoid | Write instead |
+|-------|---------------|
+| pivotal, crucial, vital | important (or cut entirely) |
+| key (adjective) | main, or rephrase |
+| testament (to) | evidence, or cut |
+| watershed moment | (state what changed) |
+| indelible mark | (state the effect) |
+| deeply rooted | long-standing, or cut |
+| lasting/enduring legacy | (state what persists) |
+| broader movement | (name the movement) |
+| evolving landscape | (state what changed) |
+| focal point | center, focus |
+| tapestry (abstract) | (cut — describe the actual thing) |
+| groundbreaking (figurative) | new, first, original |
+| captivate | interest, draw |
+| plays a significant role | matters, affects |
+| reminder (as in "is a reminder") | evidence, sign, or cut |
+| key turning point | state what changed |
+| marks/represents a shift | state what changed |
+| contributing to the | state the contribution, or cut |
+
+### False sophistication
+
+| Avoid | Write instead |
+|-------|---------------|
+| delve (into) | look at, examine, discuss |
+| intricate | detailed, complex |
+| interplay | relationship, interaction |
+| garner | get, receive, earn |
+| underscore (verb) | stress, show |
+| showcase | show, display, has |
+| foster | encourage, support |
+| encompass | include, cover |
+| align (with) | match, agree with, fit |
+| resonate (with) | appeal to, affect |
+| vibrant | (cut, or be specific) |
+| enduring | long-lasting, or cut |
+| enhance | improve |
+| nestled | located, situated, is in |
+| in the heart of | in, in central |
+| boasts | has |
+| navigate | handle, manage, deal with |
+| leverage | use |
+| elevate | raise, improve |
+| reimagine | redesign, rethink |
+| orchestrate | organize, arrange |
+| paradigm | model, approach |
+| robust | strong, reliable |
+| seamless | smooth |
+| meticulous | careful, thorough |
+| multifaceted | complex, varied |
+| bespoke | custom |
+| facilitate | help, enable, allow |
+| instrumental | important, useful |
+| highlight (verb) | show, point out |
+| exemplify | show, illustrate |
+| cultivate (figurative) | build, encourage |
+| intricacies | details, complexities |
+| valuable | useful, or cut |
+| renowned | well-known, or cut |
+| featuring | with, including, has |
+
+### Structural tics
+
+| Avoid | Write instead |
+|-------|---------------|
+| Additionally, (sentence opener) | (cut, or restructure) |
+| Furthermore, | (cut, or restructure) |
+| Moreover, | (cut, or restructure) |
+| However, (overused) | but, or restructure |
+| Therefore, (overused) | so, or restructure |
+| It is worth noting | (just state the thing) |
+| It's important to remember | (just state the thing) |
+| Despite these challenges, | (state the challenge directly) |
+| reflects broader | (name what it reflects) |
+| setting the stage for | before, leading to |
+| marking/shaping the | (rephrase without gerund) |
+| Not only X but Y | (use sparingly — max 1 per doc) |
+| In today's fast-paced world | (cut entirely) |
+| In the realm/world of | in |
+| At its core | (cut, or just state the thing) |
+| A delicate balance | (describe the actual trade-off) |
+| It is not just about X, it's Y | (rephrase without the negation setup) |
+| Challenges and Legacy (as heading) | (avoid as section title) |
+| Future Outlook (as heading) | (avoid as section title) |
+| While specific details are limited | state what's known, or say "unknown" |
+| based on available information | (cut — just state the information) |
+
+### Vague attribution
+
+| Avoid | Write instead |
+|-------|---------------|
+| Industry reports suggest | (name the report) |
+| Experts/observers/critics argue | (name the person) |
+| Some critics argue | (name the critic, or cut) |
+| several sources/publications | (name them, or say "two" if there are two) |
+| such as (before exhaustive lists) | (just list the items — don't imply more exist) |
+| profiled in | (say what the profile said, or cut) |
+| active social media presence | (state follower count or cut) |
+| independent coverage | (name the outlet and what it said) |
+
+## Structural Patterns to Avoid
+
+- **Don't end sections with summaries.** No "In summary", "In conclusion", "Overall." If the section made its point, stop.
+- **Don't write the "challenges and future" formula.** "Despite X, Y faces challenges... but the future looks promising" is the most recognizable AI paragraph structure. State problems directly without the redemptive arc.
+- **Don't create exhaustive bold-header bullet lists for everything.** "**Scalability:** The system scales well" wastes the reader's time. Use prose when content flows naturally; reserve bullet lists for genuinely list-shaped data.
+- **Don't overuse em dashes for emphasis.** One or two per page is fine. More than that reads as a stylistic tic. Prefer commas, parentheses, or colons.
+- **Don't inflate attribution.** "Featured in The New York Times and profiled by CNN" — if the citations matter, say what the sources said. If they don't, cut them.
+- **Don't create small decorative tables.** Tables work when data has two or more dimensions. For two or three items, prose is clearer.
+- **Don't write false ranges.** "From X to Y" requires X and Y to be endpoints of a real scale. "From biology to politics" is not a range.
+- **Don't use title case in headings** unless the style guide requires it. Sentence case reads more naturally.
+- **Prefer straight quotation marks.** Some AI models (notably ChatGPT and DeepSeek) default to curly quotes ("\u2026") and curly apostrophes (\u2019). Use straight quotes ("...") and straight apostrophes (') for consistency, unless the style guide specifies otherwise.
+- **Don't moralize or append safety padding.** "It is crucial to approach this topic with sensitivity" and "We must remember the human cost" are AI-generated moral wrappers. State the facts. If the facts are serious, the reader will notice without being told how to feel.
+
+## What Human Writing Actually Sounds Like
+
+Human prose has positive characteristics that AI rarely reproduces:
+
+- **Uneven sentence and paragraph length.** Some paragraphs are one sentence. Some run long. The variation isn't random — it follows the shape of the ideas.
+- **Comfortable use of "is" and "are."** Plain copulas are fine. "The bridge is 200 meters long" needs no synonym for "is."
+- **Natural repetition over forced variation.** "The bridge was built in 1910. The bridge connects the north and south banks" is better than "The structure... the span... the crossing." Elegant variation is a trap.
+- **Opinions stated plainly.** "This approach is simpler" beats "Not only is this approach more elegant, but it also serves as a more maintainable solution."
+- **Incomplete knowledge acknowledged directly.** "The date is unknown" instead of "While specific details regarding the precise date remain limited in currently available sources."
+- **Specificity over generality.** A concrete fact ("the budget was $2.4 million") is worth more than a vague claim of significance ("a substantial investment reflecting the community's commitment").
+- **Willingness to leave things unsaid.** Not every paragraph needs a concluding sentence. Not every topic needs a transition.
+
+## Reference
+
+For the complete guide with full examples, structural patterns, and the exhaustive vocabulary reference, see [REFERENCE.md](REFERENCE.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 org.gradle.jvmargs=-Xmx2g
 kotlin.code.style=official
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Feature: Add writing-prose-like-a-human skill and disable Jetifier

**Related Issue:** None

### Motivation
- Equip AI coding agents with a structured guideline and resource set (`writing-prose-like-a-human` skill) to produce natural, authentic, human-like documentation and PR content instead of typical LLM clichés.
- Optimize the Gradle build process by disabling Jetifier (`android.enableJetifier=false`), since the project has fully migrated to AndroidX and no longer needs legacy library translation support.

### Implementation
- **Architecture**: Tooling/Documentation and Configuration.
- **Key components**:
  - `.agents/skills/writing-prose-like-a-human/SKILL.md` - Definition of the writing skill instructions.
  - `.agents/skills/writing-prose-like-a-human/REFERENCE.md` - In-depth vocabulary checklist and human vs. AI patterns.
  - `.agents/skills/writing-prose-like-a-human/ATTRIBUTION.md` - Licensing/attribution details for the skill.
- **Integration points**:
  - Skill registered locally under `.agents/skills/writing-prose-like-a-human`.
  - Configured project-wide build option in `gradle.properties`.

### Changes
- `.agents/skills/writing-prose-like-a-human/SKILL.md` - Added core skill instructions.
- `.agents/skills/writing-prose-like-a-human/REFERENCE.md` - Added detailed style references.
- `.agents/skills/writing-prose-like-a-human/ATTRIBUTION.md` - Added licensing context.
- `gradle.properties:2` - Set `android.enableJetifier=false` to disable Jetifier.

### Testing

Tests results:
All unit tests passed successfully on local compilation:
```bash
JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew test
# Output: BUILD SUCCESSFUL (all unit tests passed)
```

### Notes
None.

---

_Generated by Antigravity (Gemini 3.5 Flash)_
